### PR TITLE
Fix links to point to new repo name

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,4 +1,5 @@
 ^branching_process\.Rproj$
+^branchingprocess\.Rproj$
 ^\.Rproj\.user$
 ^LICENSE\.md$
 ^\.github$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,9 +16,9 @@ Description: Quantify outbreak risk posed by individual importers of a transmiss
     and Toth et al. (2016) <doi:10.1016/j.epidem.2016.04.002>.
 License: MIT + file LICENSE
 Encoding: UTF-8
-URL: https://github.com/EpiForeSITE/branching_process,
-    https://epiforesite.github.io/branching_process/
-BugReports: https://github.com/EpiForeSITE/branching_process/issues
+URL: https://github.com/EpiForeSITE/branchingprocess,
+    https://epiforesite.github.io/branchingprocess/
+BugReports: https://github.com/EpiForeSITE/branchingprocess/issues
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2
 Imports: 

--- a/README.Rmd
+++ b/README.Rmd
@@ -6,8 +6,8 @@ output: github_document
 
 <!-- badges: start -->
 [![ForeSITE Group](https://github.com/EpiForeSITE/software/raw/e82ed88f75e0fe5c0a1a3b38c2b94509f122019c/docs/assets/foresite-software-badge.svg)](https://github.com/EpiForeSITE)
-[![R-CMD-check](https://github.com/EpiForeSITE/branching_process/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/EpiForeSITE/branching_process/actions/workflows/R-CMD-check.yaml)
-[![pkgdown](https://github.com/EpiForeSITE/branching_process/actions/workflows/pkgdown.yaml/badge.svg)](https://github.com/EpiForeSITE/branching_process/actions/workflows/pkgdown.yaml)
+[![R-CMD-check](https://github.com/EpiForeSITE/branchingprocess/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/EpiForeSITE/branchingprocess/actions/workflows/R-CMD-check.yaml)
+[![pkgdown](https://github.com/EpiForeSITE/branchingprocess/actions/workflows/pkgdown.yaml/badge.svg)](https://github.com/EpiForeSITE/branchingprocess/actions/workflows/pkgdown.yaml)
 <!-- badges: end -->
 
 ## Calculate Outbreak Probabilities for a Branching Process Model
@@ -31,7 +31,7 @@ Work to create this software tool was made possible by cooperative agreement CDC
 You can install the development version of `branchingprocess` from GitHub with:
 
 ```r
-devtools::install_github("EpiForeSITE/branching_process")
+devtools::install_github("EpiForeSITE/branchingprocess")
 ```
 You can install branchingprocess from CRAN with:
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 
 [![ForeSITE
 Group](https://github.com/EpiForeSITE/software/raw/e82ed88f75e0fe5c0a1a3b38c2b94509f122019c/docs/assets/foresite-software-badge.svg)](https://github.com/EpiForeSITE)
-[![R-CMD-check](https://github.com/EpiForeSITE/branching_process/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/EpiForeSITE/branching_process/actions/workflows/R-CMD-check.yaml)
-[![pkgdown](https://github.com/EpiForeSITE/branching_process/actions/workflows/pkgdown.yaml/badge.svg)](https://github.com/EpiForeSITE/branching_process/actions/workflows/pkgdown.yaml)
+[![R-CMD-check](https://github.com/EpiForeSITE/branchingprocess/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/EpiForeSITE/branchingprocess/actions/workflows/R-CMD-check.yaml)
+[![pkgdown](https://github.com/EpiForeSITE/branchingprocess/actions/workflows/pkgdown.yaml/badge.svg)](https://github.com/EpiForeSITE/branchingprocess/actions/workflows/pkgdown.yaml)
 <!-- badges: end -->
 
 ## Calculate Outbreak Probabilities for a Branching Process Model
@@ -40,7 +40,7 @@ You can install the development version of `branchingprocess` from
 GitHub with:
 
 ``` r
-devtools::install_github("EpiForeSITE/branching_process")
+devtools::install_github("EpiForeSITE/branchingprocess")
 ```
 
 You can install branchingprocess from CRAN with:

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -11,5 +11,5 @@ bibentry(
   ),
   year=2025,
   note=note,
-  url="https://epiforesite.github.io/branching_process/"
+  url="https://epiforesite.github.io/branchingprocess/"
   )


### PR DESCRIPTION
Merge this in after renaming the repo to "branchingprocess" to match the R package name.